### PR TITLE
ribosome.vim improvements

### DIFF
--- a/ribosome.py
+++ b/ribosome.py
@@ -330,7 +330,7 @@ linemap = []
 
 # DNA helper functions
 def dnaerror(s):
-    print "#{dnastack.last[1]}:#{$dnastack.last[2]} - #{s}"
+    print >> sys.stderr, "%s:%s - %s" %(dnastack[-1][1], dnastack[-1][2], s)
 
 # Generate new line(s) into the RNA file.
 def rnawrite(s):

--- a/ribosome.vim
+++ b/ribosome.vim
@@ -1,34 +1,46 @@
+" For CommonView to be able to set the correct syntax, the following entries must be added
+" to your ~/.vimrc file:
+" au BufNewFile,BufReadPre *.py.dna :let b:ribosome_syntax = "python"
+" au BufNewFile,BufReadPre *.js.dna :let b:ribosome_syntax = "javascript"
+" au BufNewFile,BufReadPre *.rb.dna :let b:ribosome_syntax = "ruby"
+" au BufNewFile,BufRead *.dna setf ribosome
+"
+" If you want to set a default syntax type for *.dna files, add also the following, e.g. for 
+" python:
+" let g:ribosome_default_syntax = "python"
 
 function! CommonView ()
     unlet b:current_syntax
-    syn match dot "^\..*$"
-    syn match nondot "^[^\.].*$"
-    highlight nondot ctermfg=Black guifg=Black
+    set syntax=off
+    if exists("b:ribosome_syntax")
+        let &syntax=b:ribosome_syntax
+    elseif exists("g:ribosome_default_syntax")
+        let &syntax=g:ribosome_default_syntax
+    else
+        set syntax=on
+    endif
+    syn match dot /^\s*\..*$/
     highlight dot ctermfg=Blue guifg=Blue
     let b:current_syntax = "ribosome-common"
 endfunction
 
-function! RubyView ()
-    unlet b:current_syntax
-    set syntax=off
-    set syntax=ruby
-    syn match dot "^\..*$"
-    highlight dot ctermfg=Grey guifg=Grey
-    let b:current_syntax = "ribosome-ruby"
-endfunction
-
 function! OutputView()
     unlet b:current_syntax
+    set syntax=off
+    syn match nondot /^\s*[^\.].*$/
+    highlight nondot ctermfg=Grey guifg=Grey
     if b:current_output != "none"
         execute 'syntax include @CSYN syntax/' . b:current_output . '.vim'
-        syntax region cSnip matchgroup=Snip start=/^\./ end=/$/ keepend contains=@CSYN
+        syntax region cSnip matchgroup=Snip start=/^\s*\./ end=/$/ keepend contains=@CSYN
         highlight Snip ctermfg=Grey guifg=Grey
     else
-        syn match dot "^\..*$"
-        highlight dot ctermfg=Black guifg=Black
+        syn match dot /^\s*\..*$/
+        if &background == "dark"
+            highlight dot ctermfg=White guifg=White
+        else
+            highlight dot ctermfg=Black guifg=Black
+        endif
     endif
-    syn match nondot "^[^\.].*$"
-    highlight nondot ctermfg=Grey guifg=Grey
     let b:current_syntax = "ribosome-output"
 endfunction
 
@@ -37,13 +49,13 @@ function! SetCurrentOutput(s)
     call OutputView()
 endfunction
 
-map <F2> :call CommonView()<CR>
-map <F3> :call RubyView()<CR>
+map <F3> :call CommonView()<CR>
 map <F4> :call OutputView()<CR>
+
+inoremap @ @{}<Esc>i
 
 command! -nargs=1 O call SetCurrentOutput(<f-args>)
 
 let b:current_syntax = ""
 let b:current_output = "none"
 call CommonView()
-


### PR DESCRIPTION
Hey!

So, here comes a more improved syntax file for ribosome!

First up, I modified the regular expression to identify a ribosome line to include lines that have whitespace before the dot (very useful for at least python).

For OutputView, it now checks if the background is set to dark, and if so uses White as foreground color instead of Black (black-on-dark is quite hard to look at ;))

CommonView() now uses two variables, `b:ribosome_syntax` is a buffer specific variable which is set based on the file extension (`*.py.dna`, `*.js.dna` or `*.rb,dna`) to set the syntax for the control language.
Because of this, RubyView() was removed, since it was a bit redundant.
The second variable is `g:ribosome_default_syntax`, which set the syntax colouring for the control language if there's no language specific part in the file extensions, e.g. `*.dna` files.
For CommonView() to correctly being able to set the syntax for the control language, the following should be added to your `~/.vimrc` file:

    let g:ribosome_default_syntax = "python"
    au BufNewFile,BufReadPre *.py.dna :let b:ribosome_syntax = "python"
    au BufNewFile,BufReadPre *.js.dna :let b:ribosome_syntax = "javascript"
    au BufNewFile,BufReadPre *.rb.dna :let b:ribosome_syntax = "ruby"
    au BufNewFile,BufRead *.dna setf ribosome

Last, but not least, added support fort automatically expanding @ to @{} when editing DNA files.