### PR TITLE
Support \r\n line endings with nodejs

### DIFF
--- a/ribosome.js
+++ b/ribosome.js
@@ -485,6 +485,7 @@ if (!rnaopt) {
     rnawrite('try {\n');
 }
 
+var eol = /\r?\n/;
 var dirname = path.normalize(path.dirname(dnafile));
 var file;
 try {
@@ -494,7 +495,7 @@ try {
     process.exit(1);
 }
 
-dnastack.push([file.split("\n"), dnafile, 0, dirname]);
+dnastack.push([file.split(eol), dnafile, 0, dirname]);
 
 while (dnastack.length > 1) {
 
@@ -588,7 +589,7 @@ while (dnastack.length > 1) {
             } catch (e) {
                 dnaerror("File doesn't exist.");
             }
-            dnastack.push([file.split("\n"), filename, 0, dirname]);
+            dnastack.push([file.split(eol), filename, 0, dirname]);
             continue;
         }
 


### PR DESCRIPTION
On Windows, gvim and notepad create text files with \r\n line endings instead of \n. The nodejs implementation splits the file based on \n leaving the \r behind. These \r can be inside of generated strings, causing the generated javascript to fail to parse.

The solution is to use regular express /\r?\n/ to split the string.

I examined the python and ruby implementations, but I do not believe they have the same problem since they are using "readline" and "gets" api respectively, which should handle both line endings.