### PR TITLE
fix typo in error message

### DIFF
--- a/ribosome.js
+++ b/ribosome.js
@@ -562,7 +562,7 @@ while (dnastack.length > 1) {
             dnastack.last()[2] += 1;
             if (line == null || line[0] == "." ||
                 (!line.indexOf("while") && !line.indexOf("for"))) {
-                dnaerror("'sepearate' command must be folloed by a loop.");
+                dnaerror("'separate' command must be followed by a loop.");
             }
 
             rnawrite(line);


### PR DESCRIPTION
There is a typo in an error message in the javascript implementation. Python and ruby implementation do not have the same typo.

This patch is submitted under MIT license.