### PR TITLE
Disregard unknown arguments and pass them to user script

### DIFF
--- a/ribosome.py
+++ b/ribosome.py
@@ -309,7 +309,9 @@ import argparse
 import re
 
 # Set up the arguments parser.
-parser = argparse.ArgumentParser(prog="ribosome code generator, version 1.16")
+parser = argparse.ArgumentParser(
+    prog="ribosome code generator, version 1.16",
+    usage="%(prog)s [options] <dna_file> [-- <arguments-to-dna>*]")
 parser.add_argument('dna', type=argparse.FileType('r'))
 parser.add_argument('--rna', action='store_true')
 
@@ -343,7 +345,7 @@ def rnawrite(s):
     rna.write(s)
     rnaln += len(s.splitlines())
 
-args = parser.parse_args()
+args, unknown = parser.parse_known_args()
 
 # Handle the CLI arguments.
 if args.rna:
@@ -504,7 +506,7 @@ rna.close()
 if not args.rna:
     import subprocess
     # Execute the RNA file. Pass it any arguments not used by ribosome.
-    subprocess.call([sys.executable, rnafile] + sys.argv[2:])
+    subprocess.call([sys.executable, rnafile] + unknown)
     # Delete the RNA file.
     os.remove(rnafile)
 


### PR DESCRIPTION
In order to let users build argparse based `py.dna` files, we adapt
ribosome.py to ignore all passed arguments and pass them to the resulting
user script.

## Example

With `user.py.dna`:
```python
from argparse import ArgumentParser
parser = ArgumentParser(description="generate some 'Hello, World' lines")
parser.add_argument('--count', type=int, default=3)
opts = parser.parse_args()
for x in range(0, opts.count):
    .Hello, World
```

You can now run it as:

```sh-session
$ ./ribosome.py user.py.dna -- --count 1
Hello, World

```

Or even

```sh-session
$ ./ribosome.py user.py.dna -- --help
usage: user.py.rna [-h] [--count COUNT]

generate some 'Hello, World' lines

optional arguments:
  -h, --help     show this help message and exit
  --count COUNT
```