### PR TITLE
Fix python evaluation

### DIFF
--- a/ribosome.py
+++ b/ribosome.py
@@ -240,7 +240,7 @@ class Block:
             idx = i+2 if level == 0 else i+3
             expr = line[idx:j]
             Block.stack.append([])
-            val = eval(expr, bind)
+            val = eval(expr, globals(), bind)
             top = Block.stack.pop()
             if len(top) == 0:
                 val = Block(str(val))

--- a/tests/functions2.check
+++ b/tests/functions2.check
@@ -1,0 +1,8 @@
+Colours: White       Shapes: Triangle
+         Black               Circle
+         Ultramarine
+         Red
+         Green
+         Blue
+
+That's all, folks!

--- a/tests/functions2.js.dna
+++ b/tests/functions2.js.dna
@@ -1,0 +1,25 @@
+// Tests how functions called from functions within embedded expressions are
+// evaluated
+
+function colours() {
+.    White
+.    Black
+.    Ultramarine
+.    Red
+.    Green
+.    Blue
+}
+
+function shapes() {
+.    Triangle
+.    Circle
+}
+
+function template() {
+.Colours: @{colours()} Shapes: @{shapes()}
+.
+.That's all, folks!
+}
+
+template()
+

--- a/tests/functions2.py.dna
+++ b/tests/functions2.py.dna
@@ -1,0 +1,22 @@
+# Tests how functions called from functions within embedded expressions are
+# evaluated
+
+def colours():
+    .    White
+    .    Black
+    .    Ultramarine
+    .    Red
+    .    Green
+    .    Blue
+
+def shapes():
+    .    Triangle
+    .    Circle
+
+def template():
+    .Colours: @{colours()} Shapes: @{shapes()}
+    .
+    .That's all, folks!
+
+template()
+

--- a/tests/functions2.rb.dna
+++ b/tests/functions2.rb.dna
@@ -1,0 +1,25 @@
+# Tests how functions called from functions within embedded expressions are
+# evaluated
+
+def colours()
+.    White
+.    Black
+.    Ultramarine
+.    Red
+.    Green
+.    Blue
+end
+
+def shapes()
+.    Triangle
+.    Circle
+end
+
+def template()
+.Colours: @{colours()} Shapes: @{shapes()}
+.
+.That's all, folks!
+end
+
+template()
+


### PR DESCRIPTION
I discovered what I believe is a bug in the python generator:

- when two functions, A and B are defined at the global scope
- A is evaluated inside an expression
- A uses an expression trying to evaluate B

Then the script abort with an error because B is not found in the evaluation context of  the expression inside A.

I have two commits:
 - unit test to show the, presumably, wrong behavior
 - fix

Best regards,
Frederic Jardon